### PR TITLE
修复CheckExists更新数据检查的判断条件为entity != null && !entity.Id.Equals(id)

### DIFF
--- a/src/OSharp.Core.Data.Entity/Repository.cs
+++ b/src/OSharp.Core.Data.Entity/Repository.cs
@@ -288,7 +288,7 @@ namespace OSharp.Core.Data.Entity
             var entity = _dbSet.Where(predicate).Select(m => new { m.Id }).SingleOrDefault();
             bool exists = (!(typeof(TKey).IsValueType) && id == null) || id.Equals(defaultId)
                 ? entity != null
-                : entity != null && entity.Id.Equals(id);
+                : entity != null && !entity.Id.Equals(id);
             return exists;
         }
 
@@ -428,7 +428,7 @@ namespace OSharp.Core.Data.Entity
             var entity = await _dbSet.Where(predicate).Select(m => new { m.Id }).SingleOrDefaultAsync();
             bool exists = (!(typeof(TKey).IsValueType) && id == null) || id.Equals(defaultId)
                 ? entity != null
-                : entity != null && entity.Id.Equals(id);
+                : entity != null && !entity.Id.Equals(id);
             return exists;
         }
 


### PR DESCRIPTION
原代码：entity != null && entity.Id.Equals(id)

public async Task<bool> CheckExists(Expression<Func<TEntity, bool>> predicate, TKey id = default(TKey))
        {
            TKey defaultId = default(TKey);
            var entity = await _dbSet.Where(predicate).Select(m => new { m.Id }).SingleOrDefaultAsync();
            bool exists = (!(typeof(TKey).IsValueType) && id == null) || id.Equals(defaultId)
                ? entity != null
                : entity != null && entity.Id.Equals(id);
            return exists;
        }

public async Task<bool> CheckExistsAsync(Expression<Func<TEntity, bool>> predicate, TKey id = default(TKey))
        {
            TKey defaultId = default(TKey);
            var entity = await _dbSet.Where(predicate).Select(m => new { m.Id }).SingleOrDefaultAsync();
            bool exists = (!(typeof(TKey).IsValueType) && id == null) || id.Equals(defaultId)
                ? entity != null
                : entity != null && entity.Id.Equals(id);
            return exists;
        }
修改后的：entity != null && !entity.Id.Equals(id)
public async Task<bool> CheckExists(Expression<Func<TEntity, bool>> predicate, TKey id = default(TKey))
        {
            TKey defaultId = default(TKey);
            var entity = await _dbSet.Where(predicate).Select(m => new { m.Id }).SingleOrDefaultAsync();
            bool exists = (!(typeof(TKey).IsValueType) && id == null) || id.Equals(defaultId)
                ? entity != null
                : entity != null && !entity.Id.Equals(id);
            return exists;
        }

public async Task<bool> CheckExistsAsync(Expression<Func<TEntity, bool>> predicate, TKey id = default(TKey))
        {
            TKey defaultId = default(TKey);
            var entity = await _dbSet.Where(predicate).Select(m => new { m.Id }).SingleOrDefaultAsync();
            bool exists = (!(typeof(TKey).IsValueType) && id == null) || id.Equals(defaultId)
                ? entity != null
                : entity != null && !entity.Id.Equals(id);
            return exists;
        }
